### PR TITLE
adding localhost to trusted hosts

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -706,6 +706,8 @@ $settings['container_yamls'][] = __DIR__ . '/services.yml';
 $settings['trusted_host_patterns'] = array(
   '^adventure-atlas\.com$',
   '^.+\.adventure-atlas\.com$',
+  '127.0.0.1',
+  'localhost',
 );
 $settings['install_profile'] = 'standard';
 $config_directories['sync'] = 'sites/default/config/sync';


### PR DESCRIPTION
After following the instructions it would not let me on. I got an error that my address, `127.0.0.1` from `drush runserver`, was not a trusted host pattern. This fixes it.
